### PR TITLE
Set POSIXLY_CORRECT=1 for mergehex.

### DIFF
--- a/common/conf/programmer.mk
+++ b/common/conf/programmer.mk
@@ -4,7 +4,7 @@
 UTILSPATH = $(PSOC_PROG_DIR)
 #UTILSPATH = ~/projects/PSoC/programmer
 
-MERGEHEX = $(UTILSPATH)/bin/mergehex -nm $(UTILSPATH)/config/nm.hex
+MERGEHEX = POSIXLY_CORRECT=1 $(UTILSPATH)/bin/mergehex -nm $(UTILSPATH)/config/nm.hex
 BURNCMD = $(UTILSPATH)/bin/prog -C $(UTILSPATH)/config -d $(DEVICE_NAME) program
 
 ifdef CONFIG_HEX_PATH


### PR DESCRIPTION
 This will ensure proper argument ordering on GNU/Linux and shouldn't cause problems on other systems.

Temporary fix for kiml/PSOC_programmer#3

Thanks,
Andreas
